### PR TITLE
Adreno driver cleanup

### DIFF
--- a/huashan.mk
+++ b/huashan.mk
@@ -14,8 +14,9 @@
 
 $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
 
+TARGET_PROVIDES_ADRENO_DRIVER := true
 # Inherit qcom-common files.
-$(call inherit-product, device/sony/qcom-common/qcom-common-adreno.mk)
+$(call inherit-product, device/sony/qcom-common/qcom-common.mk)
 
 DEVICE_PACKAGE_OVERLAYS += device/sony/huashan/overlay
 
@@ -254,6 +255,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Ril sends only one RIL_UNSOL_CALL_RING, so set call_ring.multiple to false
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.call_ring.multiple=0
+
+# OpenGL ES 3.0
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.opengles.version=196608
 
 # call dalvik heap config
 $(call inherit-product-if-exists, frameworks/native/build/phone-xhdpi-1024-dalvik-heap.mk)


### PR DESCRIPTION
- Keep only the current driver in qcom-common and move
  the legacy / not latest versions to the platforms needing it.
- Update makefile call / declare supported OpenGL ES version
  appropriately.

Change-Id: I7b70580638083840aaefb2aee2960218525eb3a5
