### PR TITLE
init: Add setup_fs service for Userdata

### DIFF
--- a/rootdir/init.qcom.rc
+++ b/rootdir/init.qcom.rc
@@ -580,6 +580,13 @@ service secchan /system/bin/secchand
     group root
     class core
 
+# create filesystem if necessary
+service setup_fs /system/bin/setup_fs /dev/block/platform/msm_sdcc.1/by-name/Userdata
+    class core
+    user root
+    group root
+    oneshot
+
 on property:sys.perf.profile=0
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "conservative"
     write /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor "conservative"


### PR DESCRIPTION
- Used for formatting data after unlock,
  as the userdata partition is zeroed out after unlock,
  but a filesystem isn't created.

Change-Id: I17aba9ed9778431e48f9605d10a7fde8be9b7b86
